### PR TITLE
cmake: Improved CMakeLists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,43 +10,16 @@ set(CMAKE_AUTORCC ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_CLANG_TIDY clang-tidy;)
+option(CLANG_TIDY ON)
+if(CLANG_TIDY)
+    set(CMAKE_CXX_CLANG_TIDY clang-tidy)
+endif()
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR}PrintSupport REQUIRED)
 
 set(PROJECT_SOURCES
-        main.cpp
-        resources.qrc
-        gui/welcomepage/welcomepage.h
-        gui/welcomepage/welcomepage.cpp
-        gui/welcomepage/welcomepage.ui
-        gui/mainwindow.cpp
-        gui/mainwindow.h
-        gui/mainwindow.ui
-        gui/paper.cpp
-        gui/paper.h
-        tools/draggabletool.h
-        tools/draggabletool.cpp
-        tools/texttool.h
-        tools/texttool.cpp
-        components/pagegrid.h components/pagegrid.cpp
-        tools/imagetool.h
-        tools/imagetool.cpp
-        gui/pagesetup.h
-        gui/pagesetup.cpp
-        gui/pagesetup.ui
-        gui/formulaeditor.h
-        gui/formulaeditor.cpp
-        gui/formulaeditor.ui
-        tools/formulatool.h
-        tools/formulatool.cpp
-        in_out/in_out.h
-        in_out/in_out.cpp
-        tools/tooloptions.h
-        tools/tooloptions.cpp
-        gui/document.h gui/document.cpp
         components/documentpagecontroller.h components/documentpagecontroller.cpp
         components/documenttoolbar.h components/documenttoolbar.cpp
         components/settingsscopecombo.h components/settingsscopecombo.cpp
@@ -54,6 +27,21 @@ set(PROJECT_SOURCES
         components/ruler/slider.h components/ruler/slider.cpp
         components/ruler/ruler.h components/ruler/ruler.cpp
         components/papersizecombo.h components/papersizecombo.cpp
+        components/pagegrid.h components/pagegrid.cpp
+        gui/welcomepage/welcomepage.h gui/welcomepage/welcomepage.cpp gui/welcomepage/welcomepage.ui
+        gui/mainwindow.cpp gui/mainwindow.h gui/mainwindow.ui
+        gui/paper.cpp gui/paper.h
+        gui/pagesetup.h gui/pagesetup.cpp gui/pagesetup.ui
+        gui/formulaeditor.h gui/formulaeditor.cpp gui/formulaeditor.ui
+        gui/document.h gui/document.cpp
+        tools/draggabletool.h tools/draggabletool.cpp
+        tools/texttool.h tools/texttool.cpp
+        tools/imagetool.h tools/imagetool.cpp
+        tools/formulatool.h tools/formulatool.cpp
+        tools/tooloptions.h tools/tooloptions.cpp
+        in_out/in_out.h in_out/in_out.cpp
+        main.cpp
+        resources.qrc
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
@@ -69,22 +57,10 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
             ${PROJECT_SOURCES}
         )
     endif()
-# Define target properties for Android with Qt 6 as:
-#    set_property(TARGET APDFCreator APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
-#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
-# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
-else()
-    if(ANDROID)
-        add_library(APDFCreator SHARED
-            ${PROJECT_SOURCES}
-        )
-# Define properties for Android with Qt 5 after find_package() calls as:
-#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
-    else()
-        add_executable(APDFCreator
-            ${PROJECT_SOURCES}
-        )
-    endif()
+else()   
+    add_executable(APDFCreator
+        ${PROJECT_SOURCES}
+    )
 endif()
 
 target_link_libraries(APDFCreator PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)


### PR DESCRIPTION
Removed setting unnecessary options and rearranged source files to improve readability. Added an option to make running clang-tidy optional (on by default).